### PR TITLE
fix: replace removed lucide icons

### DIFF
--- a/src/app/admin/export/page.tsx
+++ b/src/app/admin/export/page.tsx
@@ -11,16 +11,16 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Calendar } from '@/components/ui/calendar'
-import { 
-  Download, 
-  FileText, 
-  Database, 
+import {
+  Download,
+  FileText,
+  Database,
+  BarChart2,
   BarChart3,
   Users,
   MessageSquare,
-  Poll,
-  Certificate,
-  Feedback,
+  MessageCircle,
+  Award,
   Calendar as CalendarIcon,
   Filter,
   RefreshCw,
@@ -312,9 +312,9 @@ export default function AdminExportPage() {
       case 'users': return <Users className="w-4 h-4" />
       case 'registrations': return <Users className="w-4 h-4" />
       case 'questions': return <MessageSquare className="w-4 h-4" />
-      case 'polls': return <Poll className="w-4 h-4" />
-      case 'certificates': return <Certificate className="w-4 h-4" />
-      case 'feedback': return <Feedback className="w-4 h-4" />
+      case 'polls': return <BarChart2 className="w-4 h-4" />
+      case 'certificates': return <Award className="w-4 h-4" />
+      case 'feedback': return <MessageCircle className="w-4 h-4" />
       case 'financial': return <BarChart3 className="w-4 h-4" />
       default: return <FileText className="w-4 h-4" />
     }

--- a/src/app/dashboard/events/[id]/certificates/page.tsx
+++ b/src/app/dashboard/events/[id]/certificates/page.tsx
@@ -13,12 +13,12 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
-import { 
-  Certificate, 
-  Download, 
-  Plus, 
-  Edit, 
-  Trash2, 
+import {
+  Award,
+  Download,
+  Plus,
+  Edit,
+  Trash2,
   Users,
   CheckCircle,
   Clock,
@@ -407,7 +407,7 @@ Délivré le [DATE DE DÉLIVRANCE]
                               {template.autoGenerate && <Badge variant="outline">Auto</Badge>}
                             </div>
                             <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                              <Certificate className="w-4 h-4" />
+                              <Award className="w-4 h-4" />
                               {template.issuedCount}
                             </div>
                           </div>
@@ -479,7 +479,7 @@ Délivré le [DATE DE DÉLIVRANCE]
 
                     <div className="flex items-center gap-4 text-sm">
                       <span className="flex items-center gap-1">
-                        <Certificate className="w-4 h-4" />
+                        <Award className="w-4 h-4" />
                         {selectedTemplate.issuedCount} certificats délivrés
                       </span>
                       <span>Créé le {format(new Date(selectedTemplate.createdAt), 'dd/MM/yyyy à HH:mm', { locale: fr })}</span>

--- a/src/app/dashboard/events/[id]/polls/page.tsx
+++ b/src/app/dashboard/events/[id]/polls/page.tsx
@@ -13,18 +13,18 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
-import { 
-  Poll, 
-  BarChart3, 
-  Plus, 
-  Edit, 
-  Trash2, 
-  Play, 
+import {
+  BarChart3,
+  Plus,
+  Edit,
+  Trash2,
+  Play,
   Pause,
   Users,
   CheckCircle,
   Clock,
-  MoreVertical
+  MoreVertical,
+  Vote
 } from 'lucide-react'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
@@ -400,7 +400,7 @@ export default function EventPollsPage({ params }: { params: { id: string } }) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Poll className="w-5 h-5" />
+              <Vote className="w-5 h-5" />
               Sondages ({filteredPolls.length})
             </CardTitle>
           </CardHeader>

--- a/src/app/dashboard/events/[id]/recordings/page.tsx
+++ b/src/app/dashboard/events/[id]/recordings/page.tsx
@@ -13,10 +13,10 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
-import { 
-  Mic, 
-  Square, 
-  Play, 
+import {
+  Mic,
+  Square,
+  Play,
   Pause,
   Download,
   FileText,
@@ -24,7 +24,7 @@ import {
   Volume2,
   Trash2,
   Headphones,
-  Transcription,
+  AudioLines,
   Save,
   Share2
 } from 'lucide-react'
@@ -575,7 +575,7 @@ export default function EventRecordingsPage({ params }: { params: { id: string }
                           size="sm"
                           onClick={() => startTranscription(selectedRecording.id)}
                         >
-                          <Transcription className="w-4 h-4 mr-2" />
+                          <AudioLines className="w-4 h-4 mr-2" />
                           Transcrire
                         </Button>
                       )}

--- a/src/app/events/[id]/certificates/page.tsx
+++ b/src/app/events/[id]/certificates/page.tsx
@@ -7,10 +7,10 @@ import { Badge } from '@/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
-import { 
-  Certificate, 
-  Download, 
-  Mail, 
+import {
+  Award,
+  Download,
+  Mail,
   QrCode,
   CheckCircle,
   Clock,
@@ -168,7 +168,7 @@ export default function EventCertificatesPage({ params }: { params: { id: string
             </div>
             <div className="text-center">
               <div className="w-24 h-24 bg-gray-200 rounded-lg flex items-center justify-center mb-2">
-                <Certificate className="w-12 h-12 text-gray-400" />
+                <Award className="w-12 h-12 text-gray-400" />
               </div>
               <p className="text-xs text-gray-500">Signature</p>
             </div>
@@ -199,7 +199,7 @@ export default function EventCertificatesPage({ params }: { params: { id: string
       <div className="container mx-auto py-8">
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-12">
-            <Certificate className="h-12 w-12 text-muted-foreground mb-4" />
+            <Award className="h-12 w-12 text-muted-foreground mb-4" />
             <h3 className="text-lg font-semibold mb-2">Événement non trouvé</h3>
             <p className="text-muted-foreground">L'événement demandé n'existe pas.</p>
           </CardContent>
@@ -270,7 +270,7 @@ export default function EventCertificatesPage({ params }: { params: { id: string
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Certificate className="w-5 h-5" />
+              <Award className="w-5 h-5" />
               Certificats disponibles ({certificates.length})
             </CardTitle>
           </CardHeader>

--- a/src/app/events/[id]/polls/page.tsx
+++ b/src/app/events/[id]/polls/page.tsx
@@ -8,10 +8,9 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Separator } from '@/components/ui/separator'
-import { 
-  Poll, 
-  BarChart3, 
-  CheckCircle, 
+import {
+  BarChart3,
+  CheckCircle,
   Users,
   Clock,
   Vote
@@ -291,7 +290,7 @@ export default function EventPollsPage({ params }: { params: { id: string } }) {
           <div className="col-span-full">
             <Card>
               <CardContent className="flex flex-col items-center justify-center py-12">
-                <Poll className="h-12 w-12 text-muted-foreground mb-4" />
+                <Vote className="h-12 w-12 text-muted-foreground mb-4" />
                 <h3 className="text-lg font-semibold mb-2">Aucun sondage actif</h3>
                 <p className="text-muted-foreground text-center">
                   Il n'y a aucun sondage actif pour cette session.


### PR DESCRIPTION
## Summary
- replace removed lucide-react icons with supported alternatives across export, polls, certificates, and recordings pages

## Testing
- `npm run lint`
- `npx tsc --noEmit` *(fails: missing Prisma fields)*
- `npm audit` *(fails: 403 Forbidden)*
- `npm outdated` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a27f42cc28832d870e2a6605a410ba