### PR TITLE
feat: fetch registration data from server

### DIFF
--- a/src/app/api/registrations/[id]/route.ts
+++ b/src/app/api/registrations/[id]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { db } from '@/lib/db'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const registration = await db.eventRegistration.findFirst({
+      where: {
+        id: params.id,
+        isPublic: true
+      },
+      include: {
+        event: {
+          select: {
+            id: true,
+            title: true,
+            slug: true,
+            program: true
+          }
+        }
+      }
+    })
+
+    if (!registration) {
+      return NextResponse.json(
+        { error: "Inscription non trouvée" },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({
+      registration: {
+        id: registration.id,
+        firstName: registration.firstName,
+        lastName: registration.lastName,
+        email: registration.email,
+        registeredAt: registration.createdAt,
+        event: registration.event
+      }
+    })
+  } catch (error) {
+    console.error("Erreur lors de la récupération de l'inscription:", error)
+    return NextResponse.json(
+      { error: "Une erreur est survenue" },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -55,13 +55,8 @@ export default function RegisterPage() {
         throw new Error(data.error || 'Erreur lors de l\'inscription')
       }
 
-      // Stocker les informations d'inscription dans localStorage
-      localStorage.setItem('eventRegistration', JSON.stringify({
-        ...formData,
-        registeredAt: new Date().toISOString(),
-        eventId: eventId,
-        registrationId: data.registrationId
-      }))
+      // Stocker uniquement l'identifiant d'inscription dans le localStorage
+      localStorage.setItem('registrationId', data.registrationId)
       
       setIsSubmitting(false)
       setIsSubmitted(true)


### PR DESCRIPTION
## Summary
- store only registration ID client-side after event sign-up
- retrieve registration details from server using stored ID
- add API route to expose public registration information

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a28a176c04832dbdb0d75dda52ad18