### PR TITLE
fix: broadcast messages to all clients

### DIFF
--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -6,8 +6,8 @@ export const setupSocket = (io: Server) => {
     
     // Handle messages
     socket.on('message', (msg: { text: string; senderId: string }) => {
-      // Echo: broadcast message only the client who send the message
-      socket.emit('message', {
+      // Broadcast message to all connected clients
+      io.emit('message', {
         text: `Echo: ${msg.text}`,
         senderId: 'system',
         timestamp: new Date().toISOString(),
@@ -19,7 +19,7 @@ export const setupSocket = (io: Server) => {
       console.log('Client disconnected:', socket.id);
     });
 
-    // Send welcome message
+    // Send welcome message to the newly connected client
     socket.emit('message', {
       text: 'Welcome to WebSocket Echo Server!',
       senderId: 'system',


### PR DESCRIPTION
## Summary
- ensure socket messages are broadcast to all clients
- clarify comments about broadcast and welcome message behavior

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a28a18bf74832dad1192ae96c88172