### PR TITLE
refactor: secure dev routes and hash passwords

### DIFF
--- a/src/app/api/admin-simple-users/route.ts
+++ b/src/app/api/admin-simple-users/route.ts
@@ -1,29 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
-
-// Simple admin authentication (bypass NextAuth for now)
-async function getAdminUser(request: NextRequest) {
-  const authHeader = request.headers.get('authorization')
-  if (!authHeader || !authHeader.startsWith('Basic ')) {
-    return null
-  }
-
-  const base64Credentials = authHeader.split(' ')[1]
-  const credentials = Buffer.from(base64Credentials, 'base64').toString('ascii')
-  const [email, password] = credentials.split(':')
-
-  // Simple validation for demo
-  if (email === 'admin@panelevent.com' && password === 'admin123') {
-    return { id: 'admin-id', email, role: 'ADMIN' }
-  }
-
-  return null
-}
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth'
 
 export async function GET(request: NextRequest) {
   try {
-    const adminUser = await getAdminUser(request)
-    if (!adminUser) {
+    const session = await getServerSession(authOptions)
+    if (!session || session.user.role !== 'ADMIN') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 

--- a/src/app/api/admin-simple/route.ts
+++ b/src/app/api/admin-simple/route.ts
@@ -1,31 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
 
-// In-memory user store for demo
+// In-memory user store for demo with hashed passwords
 const users = [
   {
     id: 'admin-id',
     email: 'admin@panelevent.com',
     name: 'Administrateur',
     role: 'ADMIN',
-    password: 'admin123'
+    passwordHash: bcrypt.hashSync('admin123', 10)
   },
   {
     id: 'organizer-id',
     email: 'organizer@example.com',
     name: 'Organisateur Demo',
     role: 'ORGANIZER',
-    password: 'demo123'
+    passwordHash: bcrypt.hashSync('demo123', 10)
   },
   {
     id: 'attendee-id',
     email: 'attendee@example.com',
     name: 'Participant Demo',
     role: 'ATTENDEE',
-    password: 'demo123'
+    passwordHash: bcrypt.hashSync('demo123', 10)
   }
 ]
 
 export async function POST(request: NextRequest) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   try {
     const { email, password } = await request.json()
 
@@ -33,9 +38,9 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Email and password required' }, { status: 400 })
     }
 
-    const user = users.find(u => u.email === email && u.password === password)
+    const user = users.find(u => u.email === email)
 
-    if (!user) {
+    if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }
 
@@ -43,8 +48,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Access denied. Admin only.' }, { status: 403 })
     }
 
-    // Return user info without password
-    const { password: _, ...userWithoutPassword } = user
+    // Return user info without password hash
+    const { passwordHash, ...userWithoutPassword } = user
 
     return NextResponse.json({
       message: 'Admin login successful',

--- a/src/app/api/test-login/route.ts
+++ b/src/app/api/test-login/route.ts
@@ -1,31 +1,36 @@
 import { NextRequest, NextResponse } from 'next/server'
+import bcrypt from 'bcryptjs'
 
-// In-memory user store for demo
+// In-memory user store for demo with hashed passwords
 const users = [
   {
     id: 'admin-id',
     email: 'admin@panelevent.com',
     name: 'Administrateur',
     role: 'ADMIN',
-    password: 'admin123'
+    passwordHash: bcrypt.hashSync('admin123', 10)
   },
   {
     id: 'organizer-id',
     email: 'organizer@example.com',
     name: 'Organisateur Demo',
     role: 'ORGANIZER',
-    password: 'demo123'
+    passwordHash: bcrypt.hashSync('demo123', 10)
   },
   {
     id: 'attendee-id',
     email: 'attendee@example.com',
     name: 'Participant Demo',
     role: 'ATTENDEE',
-    password: 'demo123'
+    passwordHash: bcrypt.hashSync('demo123', 10)
   }
 ]
 
 export async function POST(request: NextRequest) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   try {
     const { email, password } = await request.json()
 
@@ -33,14 +38,14 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Email and password required' }, { status: 400 })
     }
 
-    const user = users.find(u => u.email === email && u.password === password)
+    const user = users.find(u => u.email === email)
 
-    if (!user) {
+    if (!user || !(await bcrypt.compare(password, user.passwordHash))) {
       return NextResponse.json({ error: 'Invalid credentials' }, { status: 401 })
     }
 
-    // Return user info without password
-    const { password: _, ...userWithoutPassword } = user
+    // Return user info without password hash
+    const { passwordHash, ...userWithoutPassword } = user
 
     return NextResponse.json({
       message: 'Login successful',

--- a/src/app/api/test-nextauth/route.ts
+++ b/src/app/api/test-nextauth/route.ts
@@ -3,6 +3,10 @@ import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 
 export async function GET() {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   try {
     console.log('Testing NextAuth configuration...')
     console.log('Auth options providers:', authOptions.providers?.length)

--- a/src/app/api/test-users/route.ts
+++ b/src/app/api/test-users/route.ts
@@ -2,6 +2,10 @@ import { NextResponse } from 'next/server'
 import { db } from '@/lib/db'
 
 export async function GET() {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
   try {
     const users = await db.user.findMany({
       select: {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,31 @@
 import NextAuth from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
+import bcrypt from 'bcryptjs'
+
+// Demo users with hashed passwords
+const demoUsers = [
+  {
+    id: 'admin-id',
+    email: 'admin@panelevent.com',
+    name: 'Administrateur',
+    role: 'ADMIN',
+    passwordHash: bcrypt.hashSync('admin123', 10)
+  },
+  {
+    id: 'organizer-id',
+    email: 'organizer@example.com',
+    name: 'Organisateur Demo',
+    role: 'ORGANIZER',
+    passwordHash: bcrypt.hashSync('demo123', 10)
+  },
+  {
+    id: 'attendee-id',
+    email: 'attendee@example.com',
+    name: 'Participant Demo',
+    role: 'ATTENDEE',
+    passwordHash: bcrypt.hashSync('demo123', 10)
+  }
+]
 
 const authOptions = {
   providers: [
@@ -12,43 +38,19 @@ const authOptions = {
       },
       async authorize(credentials) {
         console.log('Authorize function called with:', credentials?.email)
-        
+
         if (!credentials?.email || !credentials?.password) {
           console.log('Missing credentials')
           return null
         }
 
-        // Simple validation for demo
-        if (credentials?.email === 'admin@panelevent.com' && credentials?.password === 'admin123') {
-          console.log('Admin authentication successful')
-          return {
-            id: 'admin-id',
-            email: 'admin@panelevent.com',
-            name: 'Administrateur',
-            role: 'ADMIN'
-          }
+        const user = demoUsers.find(u => u.email === credentials.email)
+        if (user && await bcrypt.compare(credentials.password, user.passwordHash)) {
+          console.log(`${user.role} authentication successful`)
+          const { passwordHash, ...userWithoutPassword } = user
+          return userWithoutPassword
         }
-        
-        if (credentials?.email === 'organizer@example.com' && credentials?.password === 'demo123') {
-          console.log('Organizer authentication successful')
-          return {
-            id: 'organizer-id',
-            email: 'organizer@example.com',
-            name: 'Organisateur Demo',
-            role: 'ORGANIZER'
-          }
-        }
-        
-        if (credentials?.email === 'attendee@example.com' && credentials?.password === 'demo123') {
-          console.log('Attendee authentication successful')
-          return {
-            id: 'attendee-id',
-            email: 'attendee@example.com',
-            name: 'Participant Demo',
-            role: 'ATTENDEE'
-          }
-        }
-        
+
         console.log('Authentication failed')
         return null
       }


### PR DESCRIPTION
## Summary
- restrict test API routes to development builds
- hash demo user passwords and verify with bcrypt
- secure admin user endpoint with NextAuth sessions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a28a19bfd8832db1d5fde541105097