### PR TITLE
Enforce auth and validate data for event creation

### DIFF
--- a/src/app/events/create/page.tsx
+++ b/src/app/events/create/page.tsx
@@ -35,8 +35,7 @@ export default function CreateEvent() {
         },
         body: JSON.stringify({
           ...formData,
-          slug,
-          organizerId: session?.user?.id
+          slug
         })
       })
 
@@ -44,8 +43,11 @@ export default function CreateEvent() {
         router.push('/dashboard/events')
       } else {
         const error = await response.json()
-        console.error('Failed to create event:', error.error)
-        alert(error.error || 'Erreur lors de la création de l\'événement')
+        console.error('Failed to create event:', error)
+        const message = Array.isArray(error.details)
+          ? `${error.error}: ${error.details.join(', ')}`
+          : error.error
+        alert(message || 'Erreur lors de la création de l\'événement')
       }
     } catch (error) {
       console.error('Error creating event:', error)


### PR DESCRIPTION
## Summary
- require organizer/Admin session before creating events
- validate event payload with Zod and return sanitized errors
- rely on session user on event creation page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a28a1cb16c832dbd635ff04a3575dc