### PR TITLE
feat: secure websocket connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ npm start
 
 Open [http://localhost:3000](http://localhost:3000) to see your application running.
 
+## 🔧 WebSocket Configuration
+
+Set allowed origins for Socket.IO connections using the `WS_ALLOWED_ORIGINS` environment variable (comma-separated list). To require a token for clients, set `WEBSOCKET_AUTH_TOKEN` and provide the same token when connecting.
+
 ## 🤖 Powered by Z.ai
 
 This scaffold is optimized for use with [Z.ai](https://chat.z.ai) - your AI assistant for:

--- a/server.ts
+++ b/server.ts
@@ -32,12 +32,13 @@ async function createCustomServer() {
     });
 
     // Setup Socket.IO
+    const allowedOrigins = process.env.WS_ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean) ?? [];
     const io = new Server(server, {
       path: '/api/socketio',
       cors: {
-        origin: "*",
-        methods: ["GET", "POST"]
-      }
+        origin: allowedOrigins,
+        methods: ['GET', 'POST'],
+      },
     });
 
     setupSocket(io);

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,6 +1,16 @@
 import { Server } from 'socket.io';
 
 export const setupSocket = (io: Server) => {
+  const authToken = process.env.WEBSOCKET_AUTH_TOKEN;
+  if (authToken) {
+    io.use((socket, next) => {
+      const token = (socket.handshake.auth as any)?.token || (socket.handshake.query as any)?.token;
+      if (token !== authToken) {
+        return next(new Error('Unauthorized'));
+      }
+      next();
+    });
+  }
   io.on('connection', (socket) => {
     console.log('Client connected:', socket.id);
     


### PR DESCRIPTION
## Summary
- restrict Socket.IO origins to an environment-defined allow list
- add optional token authentication middleware for websocket connections
- document websocket environment variables

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a28a2257f8832dafbe4b15a9c4db67