### PR TITLE
feat: add RLS policies and indexes

### DIFF
--- a/supabase/migrations/202402270000_rls_policies.sql
+++ b/supabase/migrations/202402270000_rls_policies.sql
@@ -1,0 +1,46 @@
+-- Enable Row Level Security on all tables
+ALTER TABLE users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE panels ENABLE ROW LEVEL SECURITY;
+ALTER TABLE event_registrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE questions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE polls ENABLE ROW LEVEL SECURITY;
+ALTER TABLE poll_options ENABLE ROW LEVEL SECURITY;
+ALTER TABLE poll_responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE certificate_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE certificates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE feedbacks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE helpful_votes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE registration_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Additional indexes for frequent queries
+CREATE INDEX IF NOT EXISTS event_registrations_user_id_idx ON event_registrations(user_id);
+CREATE INDEX IF NOT EXISTS poll_responses_poll_id_idx ON poll_responses(poll_id);
+
+-- RLS Policies
+-- Users
+CREATE POLICY "Users can view own data" ON users
+  FOR SELECT USING (auth.uid() = id);
+CREATE POLICY "Users can update own data" ON users
+  FOR UPDATE USING (auth.uid() = id);
+CREATE POLICY "Users can insert own row" ON users
+  FOR INSERT WITH CHECK (auth.uid() = id);
+
+-- Events
+CREATE POLICY "Events are viewable by everyone" ON events
+  FOR SELECT USING (true);
+CREATE POLICY "Organizers manage events" ON events
+  FOR ALL USING (auth.uid() = organizer_id) WITH CHECK (auth.uid() = organizer_id);
+
+-- Event registrations
+CREATE POLICY "Users view own registrations" ON event_registrations
+  FOR SELECT USING (
+    auth.uid() = user_id
+    OR auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id)
+  );
+CREATE POLICY "Users manage own registrations" ON event_registrations
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Poll responses
+CREATE POLICY "Users manage own poll responses" ON poll_responses
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -1,0 +1,35 @@
+-- Documentation des politiques RLS pour Supabase
+
+-- Table: users
+--   - Users can view/update/insert only their own record.
+--   - Policies:
+--       CREATE POLICY "Users can view own data" ON users
+--         FOR SELECT USING (auth.uid() = id);
+--       CREATE POLICY "Users can update own data" ON users
+--         FOR UPDATE USING (auth.uid() = id);
+--       CREATE POLICY "Users can insert own row" ON users
+--         FOR INSERT WITH CHECK (auth.uid() = id);
+
+-- Table: events
+--   - All users can view events.
+--   - Only the organizer (auth.uid() = organizer_id) can insert, update or delete.
+--       CREATE POLICY "Events are viewable by everyone" ON events
+--         FOR SELECT USING (true);
+--       CREATE POLICY "Organizers manage events" ON events
+--         FOR ALL USING (auth.uid() = organizer_id) WITH CHECK (auth.uid() = organizer_id);
+
+-- Table: event_registrations
+--   - Users can view their own registrations and organizers can view registrations for their events.
+--   - Users can insert/update/delete only their own registrations.
+--       CREATE POLICY "Users view own registrations" ON event_registrations
+--         FOR SELECT USING (
+--           auth.uid() = user_id
+--           OR auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id)
+--         );
+--       CREATE POLICY "Users manage own registrations" ON event_registrations
+--         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Table: poll_responses
+--   - Users can insert/update/delete only their own responses.
+--       CREATE POLICY "Users manage own poll responses" ON poll_responses
+--         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- enable row level security and define policies for users, events, registrations, and poll responses
- add indexes for frequent queries on event registrations and poll responses
- document RLS policies in `supabase/policies.sql`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4df822df0832d9d7ea10e39279bd7