### PR TITLE
feat: adopt Supabase event types

### DIFF
--- a/src/app/organizer/events/page.tsx
+++ b/src/app/organizer/events/page.tsx
@@ -5,10 +5,10 @@ import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 import CreateEventDialog from '@/components/organizer/CreateEventDialog'
 import { EventsTable } from '@/components/organizer/EventsTable'
-import { Event } from '@prisma/client'
+import type { Database } from '@/types/supabase'
 
 export default function OrganizerEventsPage() {
-  const [events, setEvents] = useState<Event[]>([])
+  const [events, setEvents] = useState<Database['public']['Tables']['events']['Row'][]>([])
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false)
 
   const fetchEvents = async () => {

--- a/src/components/organizer/EditEventDialog.tsx
+++ b/src/components/organizer/EditEventDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Event } from '@prisma/client'
+import type { Database } from '@/types/supabase'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Edit } from 'lucide-react'
@@ -11,7 +11,7 @@ export default function EditEventDialog({
   event,
   onSuccess,
 }: {
-  event: Event
+  event: Database['public']['Tables']['events']['Row']
   onSuccess: () => void
 }) {
   const [isOpen, setIsOpen] = useState(false)

--- a/src/components/organizer/EditEventForm.tsx
+++ b/src/components/organizer/EditEventForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Event } from '@prisma/client'
+import type { Database } from '@/types/supabase'
 import { useForm } from 'react-hook-form'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -14,7 +14,7 @@ export default function EditEventForm({
   event,
   onSuccess,
 }: {
-  event: Event
+  event: Database['public']['Tables']['events']['Row']
   onSuccess: () => void
 }) {
   const { register, handleSubmit, setValue, watch } = useForm({

--- a/src/components/organizer/EventActions.tsx
+++ b/src/components/organizer/EventActions.tsx
@@ -7,10 +7,10 @@ import { QRCodeGenerator } from '@/components/QRCodeGenerator'
 import EditEventDialog from '@/components/organizer/EditEventDialog'
 import { DeleteEventModal } from '@/components/organizer/DeleteEventModal'
 import { useState } from 'react'
-import { Event } from '@prisma/client'
+import type { Database } from '@/types/supabase'
 
 interface EventActionsProps {
-  event: Event
+  event: Database['public']['Tables']['events']['Row']
   onRefresh: () => void
 }
 

--- a/src/components/organizer/EventsTable.tsx
+++ b/src/components/organizer/EventsTable.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Event } from '@prisma/client'
+import type { Database } from '@/types/supabase'
 import { ColumnDef } from '@tanstack/react-table'
 import { DataTable } from '@/components/ui/data-table'
 import { format } from 'date-fns'
@@ -8,13 +8,13 @@ import { fr } from 'date-fns/locale'
 import { EventActions } from '@/components/organizer/EventActions'
 
 interface EventsTableProps {
-  events: Event[]
+  events: Database['public']['Tables']['events']['Row'][]
   onRefresh: () => void
 }
 
 
 export function EventsTable({ events, onRefresh }: EventsTableProps) {
-  const columnsWithRefresh: ColumnDef<Event>[] = [
+  const columnsWithRefresh: ColumnDef<Database['public']['Tables']['events']['Row']>[] = [
     {
       accessorKey: 'title',
       header: 'Titre',

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,0 +1,75 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      events: {
+        Row: {
+          id: string;
+          title: string;
+          description: string | null;
+          slug: string;
+          startDate: string;
+          endDate: string | null;
+          location: string | null;
+          isPublic: boolean;
+          isActive: boolean;
+          branding: Json | null;
+          program: string | null;
+          qrCode: string | null;
+          maxAttendees: number | null;
+          createdAt: string;
+          updatedAt: string;
+          organizerId: string;
+        };
+        Insert: {
+          id?: string;
+          title: string;
+          description?: string | null;
+          slug: string;
+          startDate: string;
+          endDate?: string | null;
+          location?: string | null;
+          isPublic?: boolean;
+          isActive?: boolean;
+          branding?: Json | null;
+          program?: string | null;
+          qrCode?: string | null;
+          maxAttendees?: number | null;
+          createdAt?: string;
+          updatedAt?: string;
+          organizerId: string;
+        };
+        Update: {
+          id?: string;
+          title?: string;
+          description?: string | null;
+          slug?: string;
+          startDate?: string;
+          endDate?: string | null;
+          location?: string | null;
+          isPublic?: boolean;
+          isActive?: boolean;
+          branding?: Json | null;
+          program?: string | null;
+          qrCode?: string | null;
+          maxAttendees?: number | null;
+          createdAt?: string;
+          updatedAt?: string;
+          organizerId?: string;
+        };
+        Relationships: [];
+      };
+    };
+    Views: Record<string, never>;
+    Functions: Record<string, never>;
+    Enums: Record<string, never>;
+    CompositeTypes: Record<string, never>;
+  };
+}


### PR DESCRIPTION
## Summary
- add manually crafted Supabase Database types
- replace Prisma `Event` imports with Supabase `events` row type

## Testing
- `npm run lint`
- `npx supabase --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4df833c58832d8e0fbc47bf773109