### PR TITLE
refactor: migrate panels and program to supabase

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@mdxeditor/editor": "^3.39.1",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.14.0",
+    "@supabase/supabase-js": "^2.43.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",
     "@radix-ui/react-aspect-ratio": "^1.1.7",

--- a/src/app/api/admin/events/[id]/route.ts
+++ b/src/app/api/admin/events/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '@/lib/auth'
 import { db } from '@/lib/db'
+import { supabase } from '@/lib/supabase'
 
 export async function GET(
   request: NextRequest,
@@ -84,38 +85,34 @@ export async function PATCH(
 
     const { title, description, startDate, endDate, location, isPublic, isActive, organizerId } = await request.json()
 
-    interface UpdateData {
-      title?: string
-      slug?: string
-      description?: string
-      startDate?: Date
-      endDate?: Date | null
-      location?: string
-      isPublic?: boolean
-      isActive?: boolean
-      organizerId?: string
-    }
-
-    const updateData: UpdateData = {}
+    const updateData: Record<string, any> = {}
     if (title !== undefined) {
       updateData.title = title
-      // Update slug if title changes
       updateData.slug = title
         .toLowerCase()
         .replace(/[^a-z0-9]+/g, '-')
         .replace(/(^-|-$)/g, '')
     }
     if (description !== undefined) updateData.description = description
-    if (startDate !== undefined) updateData.startDate = new Date(startDate)
-    if (endDate !== undefined) updateData.endDate = endDate ? new Date(endDate) : null
+    if (startDate !== undefined) updateData.startDate = new Date(startDate).toISOString()
+    if (endDate !== undefined) updateData.endDate = endDate ? new Date(endDate).toISOString() : null
     if (location !== undefined) updateData.location = location
     if (isPublic !== undefined) updateData.isPublic = isPublic
     if (isActive !== undefined) updateData.isActive = isActive
     if (organizerId !== undefined) updateData.organizerId = organizerId
 
-    const event = await db.event.update({
+    const { error: updateError } = await supabase
+      .from('events')
+      .update(updateData)
+      .eq('id', resolvedParams.id)
+
+    if (updateError) {
+      console.error('Failed to update event:', updateError)
+      return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    }
+
+    const event = await db.event.findUnique({
       where: { id: resolvedParams.id },
-      data: updateData,
       include: {
         organizer: {
           select: {
@@ -156,6 +153,17 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    // Delete related panels using Supabase
+    const { error: panelError } = await supabase
+      .from('panels')
+      .delete()
+      .eq('eventId', resolvedParams.id)
+
+    if (panelError) {
+      console.error('Failed to delete panels:', panelError)
+      return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
+    }
+
     // Delete related data first due to foreign key constraints
     await db.$transaction([
       db.eventRegistration.deleteMany({
@@ -171,9 +179,6 @@ export async function DELETE(
         where: { eventId: resolvedParams.id }
       }),
       db.certificate.deleteMany({
-        where: { eventId: resolvedParams.id }
-      }),
-      db.panel.deleteMany({
         where: { eventId: resolvedParams.id }
       }),
       db.event.delete({

--- a/src/app/api/events/[id]/polls/route.ts
+++ b/src/app/api/events/[id]/polls/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
+import { supabase } from '@/lib/supabase'
 import { Prisma } from '@prisma/client'
 
 // GET /api/events/[id]/polls - Récupérer tous les sondages d'un événement
@@ -91,14 +92,14 @@ export async function POST(
     }
 
     // Vérifier que le panel appartient à l'événement
-    const panel = await db.panel.findFirst({
-      where: {
-        id: panelId,
-        eventId: id
-      }
-    })
+    const { data: panel, error: panelError } = await supabase
+      .from('panels')
+      .select('id')
+      .eq('id', panelId)
+      .eq('eventId', id)
+      .single()
 
-    if (!panel) {
+    if (panelError || !panel) {
       return NextResponse.json(
         { error: 'Panel not found or does not belong to this event' },
         { status: 404 }

--- a/src/app/api/events/[id]/questions/route.ts
+++ b/src/app/api/events/[id]/questions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { db } from '@/lib/db'
+import { supabase } from '@/lib/supabase'
 import { Prisma, QuestionStatus } from '@prisma/client'
 
 // GET /api/events/[id]/questions - Récupérer toutes les questions d'un événement
@@ -90,14 +91,14 @@ export async function POST(
     }
 
     // Vérifier que le panel appartient à l'événement
-    const panel = await db.panel.findFirst({
-      where: {
-        id: panelId,
-        eventId: id
-      }
-    })
+    const { data: panel, error: panelError } = await supabase
+      .from('panels')
+      .select('id')
+      .eq('id', panelId)
+      .eq('eventId', id)
+      .single()
 
-    if (!panel) {
+    if (panelError || !panel) {
       return NextResponse.json(
         { error: 'Panel not found or does not belong to this event' },
         { status: 404 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.SUPABASE_URL
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+if (!supabaseUrl || !supabaseKey) {
+  throw new Error('Missing Supabase environment variables')
+}
+
+export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- switch panel CRUD endpoints to use Supabase queries with `eq` and `order`
- update admin event and program endpoints to call Supabase instead of Prisma
- add Supabase client and dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4df874254832db999b1ec12fd3c57