### PR TITLE
feat: migrate questions API to supabase

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@tanstack/react-query": "^5.82.0",
     "@tanstack/react-table": "^8.21.3",
     "@types/qrcode": "^1.5.5",
+    "@supabase/supabase-js": "^2.0.0",
     "axios": "^1.10.0",
     "bcryptjs": "^3.0.2",
     "class-variance-authority": "^0.7.1",

--- a/src/app/api/events/[id]/questions/route.ts
+++ b/src/app/api/events/[id]/questions/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/lib/db'
-import { Prisma, QuestionStatus } from '@prisma/client'
+import { supabase } from '@/lib/supabase'
 
 // GET /api/events/[id]/questions - Récupérer toutes les questions d'un événement
 export async function GET(
@@ -15,51 +14,47 @@ export async function GET(
     const status = searchParams.get('status')
     const search = searchParams.get('search')
 
-    const whereClause: Prisma.QuestionWhereInput = {
-      panel: {
-        eventId: id
-      }
-    }
+    let query = supabase
+      .from('questions')
+      .select(
+        `*, panel:panels!inner(id,title,start_time,end_time)`
+      )
+      .eq('panel.event_id', id)
+      .order('created_at', { ascending: false })
 
     if (panelId) {
-      whereClause.panelId = panelId
+      query = query.eq('panel_id', panelId)
     }
 
     if (status && status !== 'all') {
-      whereClause.status = status.toUpperCase() as QuestionStatus
+      query = query.eq('status', status.toUpperCase())
     }
 
     if (search) {
-      whereClause.OR = [
-        { content: { contains: search } },
-        { authorName: { contains: search } }
-      ]
+      query = query.or(
+        `content.ilike.%${search}%,author_name.ilike.%${search}%`
+      )
     }
 
-    const questions = await db.question.findMany({
-      where: whereClause,
-      include: {
-        panel: {
-          select: {
-            id: true,
-            title: true,
-            startTime: true,
-            endTime: true
-          }
-        },
-        votes: true
-      },
-      orderBy: {
-        createdAt: 'desc'
+    const { data: questions, error } = await query
+    if (error) throw error
+
+    const questionIds = questions.map(q => q.id)
+    const { data: voteCounts } = await supabase.rpc(
+      'get_question_vote_counts',
+      { question_ids: questionIds }
+    )
+
+    const questionsWithVotes = questions.map(question => {
+      const vote = voteCounts?.find(
+        (v: any) => v.question_id === question.id
+      ) || { upvotes: 0, downvotes: 0 }
+      return {
+        ...question,
+        upvotes: vote.upvotes,
+        downvotes: vote.downvotes
       }
     })
-
-    // Calculer les votes
-    const questionsWithVotes = questions.map(question => ({
-      ...question,
-      upvotes: question.votes.filter(vote => vote.type === 'UP').length,
-      downvotes: question.votes.filter(vote => vote.type === 'DOWN').length
-    }))
 
     return NextResponse.json(questionsWithVotes)
   } catch (error) {
@@ -90,40 +85,36 @@ export async function POST(
     }
 
     // Vérifier que le panel appartient à l'événement
-    const panel = await db.panel.findFirst({
-      where: {
-        id: panelId,
-        eventId: id
-      }
-    })
+    const {
+      data: panel,
+      error: panelError
+    } = await supabase
+      .from('panels')
+      .select('id,title,start_time,end_time')
+      .eq('id', panelId)
+      .eq('event_id', id)
+      .single()
 
-    if (!panel) {
+    if (panelError || !panel) {
       return NextResponse.json(
         { error: 'Panel not found or does not belong to this event' },
         { status: 404 }
       )
     }
 
-    const question = await db.question.create({
-      data: {
+    const { data: question, error } = await supabase
+      .from('questions')
+      .insert({
         content,
-        panelId,
-        authorName,
-        authorEmail,
+        panel_id: panelId,
+        author_name: authorName,
+        author_email: authorEmail,
         status: 'PENDING'
-      },
-      include: {
-        panel: {
-          select: {
-            id: true,
-            title: true,
-            startTime: true,
-            endTime: true
-          }
-        },
-        votes: true
-      }
-    })
+      })
+      .select(`*, panel:panels(id,title,start_time,end_time)`)
+      .single()
+
+    if (error) throw error
 
     return NextResponse.json(question)
   } catch (error) {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,9 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ''
+
+export const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: false }
+})


### PR DESCRIPTION
## Summary
- use Supabase client for questions APIs
- handle question vote counts with RPC
- add Supabase dependency and client helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4df8afd74832dbe44594b5881205f