### PR TITLE
refactor: replace prisma with supabase in event routes

### DIFF
--- a/src/app/api/events/[id]/feedback/route.ts
+++ b/src/app/api/events/[id]/feedback/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/lib/db'
 import { supabase } from '@/lib/supabase'
-import { Prisma } from '@prisma/client'
 
 // GET /api/events/[id]/feedback - Récupérer tous les feedbacks d'un événement
 export async function GET(
@@ -16,43 +14,33 @@ export async function GET(
     const rating = searchParams.get('rating')
     const resolved = searchParams.get('resolved')
 
-    const whereClause: Prisma.FeedbackWhereInput = {
-      eventId: id
-    }
+    let query = supabase
+      .from('feedbacks')
+      .select(
+        `*, user:users(id,name,email), helpfulVotes:helpful_votes(user_id)`
+      )
+      .eq('event_id', id)
+      .order('created_at', { ascending: false })
 
     if (category) {
-      whereClause.category = category
+      query = query.eq('category', category)
     }
 
     if (rating) {
-      whereClause.rating = parseInt(rating)
+      query = query.eq('rating', parseInt(rating))
     }
 
     if (resolved !== null) {
-      whereClause.resolved = resolved === 'true'
+      query = query.eq('resolved', resolved === 'true')
     }
 
-    const feedbacks = await db.feedback.findMany({
-      where: whereClause,
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true
-          }
-        },
-        helpfulVotes: true
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: feedbacks, error } = await query
+    if (error) throw error
 
     // Calculer les votes utiles
-    const feedbacksWithVotes = feedbacks.map(feedback => ({
+    const feedbacksWithVotes = (feedbacks || []).map(feedback => ({
       ...feedback,
-      helpful: feedback.helpfulVotes.length
+      helpful: feedback.helpfulVotes?.length || 0
     }))
 
     return NextResponse.json(feedbacksWithVotes)
@@ -94,12 +82,8 @@ export async function POST(
     const { data: registration } = await supabase
       .from('event_registrations')
       .select('id')
-      .eq('userId', userId)
-      .eq('eventId', id)
-
       .eq('user_id', userId)
       .eq('event_id', id)
-
       .eq('attended', true)
       .maybeSingle()
 
@@ -111,12 +95,12 @@ export async function POST(
     }
 
     // Vérifier si l'utilisateur a déjà laissé un feedback
-    const existingFeedback = await db.feedback.findFirst({
-      where: {
-        userId,
-        eventId: id
-      }
-    })
+    const { data: existingFeedback } = await supabase
+      .from('feedbacks')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('event_id', id)
+      .maybeSingle()
 
     if (existingFeedback) {
       return NextResponse.json(
@@ -124,31 +108,26 @@ export async function POST(
         { status: 400 }
       )
     }
-
-    const feedback = await db.feedback.create({
-      data: {
-        userId,
-        eventId: id,
+    const { data: feedback, error: feedbackError } = await supabase
+      .from('feedbacks')
+      .insert({
+        user_id: userId,
+        event_id: id,
         rating,
         comment: comment || null,
         category,
         resolved: false
-      },
-      include: {
-        user: {
-          select: {
-            id: true,
-            name: true,
-            email: true
-          }
-        },
-        helpfulVotes: true
-      }
-    })
+      })
+      .select(
+        `*, user:users(id,name,email), helpfulVotes:helpful_votes(user_id)`
+      )
+      .single()
+
+    if (feedbackError) throw feedbackError
 
     const feedbackWithVotes = {
       ...feedback,
-      helpful: feedback.helpfulVotes.length
+      helpful: feedback.helpfulVotes?.length || 0
     }
 
     return NextResponse.json(feedbackWithVotes)

--- a/src/app/api/events/[id]/polls/route.ts
+++ b/src/app/api/events/[id]/polls/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { db } from '@/lib/db'
 import { supabase } from '@/lib/supabase'
-import { Prisma } from '@prisma/client'
 
 // GET /api/events/[id]/polls - Récupérer tous les sondages d'un événement
 export async function GET(
@@ -14,46 +12,35 @@ export async function GET(
     const { searchParams } = new URL(request.url)
     const panelId = searchParams.get('panelId')
 
-    const whereClause: Prisma.PollWhereInput = {
-      panel: {
-        eventId: id
-      }
-    }
+    let query = supabase
+      .from('polls')
+      .select(
+        `*, panel:panels!inner(id,title,start_time,end_time), options:poll_options(*, responses:poll_responses(id))`
+      )
+      .eq('panel.event_id', id)
+      .order('created_at', { ascending: false })
 
     if (panelId) {
-      whereClause.panelId = panelId
+      query = query.eq('panel_id', panelId)
     }
 
-    const polls = await db.poll.findMany({
-      where: whereClause,
-      include: {
-        panel: {
-          select: {
-            id: true,
-            title: true,
-            startTime: true,
-            endTime: true
-          }
-        },
-        options: {
-          include: {
-            responses: true
-          }
-        }
-      },
-      orderBy: {
-        createdAt: 'desc'
-      }
-    })
+    const { data: polls, error } = await query
+    if (error) throw error
 
     // Calculer les votes et pourcentages
-    const pollsWithStats = polls.map(poll => {
-      const totalVotes = poll.options.reduce((sum, option) => sum + option.responses.length, 0)
-      
-      const optionsWithStats = poll.options.map(option => ({
+    const pollsWithStats = (polls || []).map(poll => {
+      const totalVotes = poll.options?.reduce(
+        (sum: number, option: any) => sum + option.responses.length,
+        0
+      ) || 0
+
+      const optionsWithStats = (poll.options || []).map((option: any) => ({
         ...option,
         votes: option.responses.length,
-        percentage: totalVotes > 0 ? Math.round((option.responses.length / totalVotes) * 100) : 0
+        percentage:
+          totalVotes > 0
+            ? Math.round((option.responses.length / totalVotes) * 100)
+            : 0
       }))
 
       return {
@@ -96,7 +83,7 @@ export async function POST(
       .from('panels')
       .select('id')
       .eq('id', panelId)
-      .eq('eventId', id)
+      .eq('event_id', id)
       .single()
 
     if (panelError || !panel) {
@@ -106,41 +93,46 @@ export async function POST(
       )
     }
 
-    // Créer le sondage avec ses options
-    const poll = await db.poll.create({
-      data: {
+    const { data: createdPoll, error: pollError } = await supabase
+      .from('polls')
+      .insert({
         question,
         description,
-        panelId,
-        isAnonymous: isAnonymous || false,
-        allowMultipleVotes: allowMultipleVotes || false,
-        options: {
-          create: options.map((optionText: string, index: number) => ({
-            text: optionText,
-            order: index
-          }))
-        }
-      },
-      include: {
-        panel: {
-          select: {
-            id: true,
-            title: true,
-            startTime: true,
-            endTime: true
-          }
-        },
-        options: {
-          include: {
-            responses: true
-          }
-        }
-      }
-    })
+        panel_id: panelId,
+        event_id: id,
+        is_anonymous: isAnonymous || false,
+        allow_multiple_votes: allowMultipleVotes || false
+      })
+      .select('id')
+      .single()
 
-    // Calculer les stats initiales
-    const totalVotes = poll.options.reduce((sum, option) => sum + option.responses.length, 0)
-    const optionsWithStats = poll.options.map(option => ({
+    if (pollError || !createdPoll) throw pollError
+
+    const { error: optionsError } = await supabase.from('poll_options').insert(
+      options.map((optionText: string, index: number) => ({
+        poll_id: createdPoll.id,
+        text: optionText,
+        order: index
+      }))
+    )
+
+    if (optionsError) throw optionsError
+
+    const { data: poll, error: fetchError } = await supabase
+      .from('polls')
+      .select(
+        `*, panel:panels(id,title,start_time,end_time), options:poll_options(*, responses:poll_responses(id))`
+      )
+      .eq('id', createdPoll.id)
+      .single()
+
+    if (fetchError || !poll) throw fetchError
+
+    const totalVotes = poll.options.reduce(
+      (sum: number, option: any) => sum + option.responses.length,
+      0
+    )
+    const optionsWithStats = poll.options.map((option: any) => ({
       ...option,
       votes: option.responses.length,
       percentage: 0

--- a/src/app/api/events/[id]/questions/route.ts
+++ b/src/app/api/events/[id]/questions/route.ts
@@ -1,8 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
-
-import { supabase } from '@/lib/supabase'
-import { Prisma, QuestionStatus } from '@prisma/client'
+import type { QuestionStatus } from '@/types/supabase'
 
 
 // GET /api/events/[id]/questions - Récupérer toutes les questions d'un événement
@@ -90,20 +88,11 @@ export async function POST(
 
     // Vérifier que le panel appartient à l'événement
 
-    const {
-      data: panel,
-      error: panelError
-    } = await supabase
-      .from('panels')
-      .select('id,title,start_time,end_time')
-      .eq('id', panelId)
-      .eq('event_id', id)
-
     const { data: panel, error: panelError } = await supabase
       .from('panels')
       .select('id')
       .eq('id', panelId)
-      .eq('eventId', id)
+      .eq('event_id', id)
       .single()
 
     if (panelError || !panel) {
@@ -120,7 +109,7 @@ export async function POST(
         panel_id: panelId,
         author_name: authorName,
         author_email: authorEmail,
-        status: 'PENDING'
+        status: 'PENDING' as QuestionStatus
       })
       .select(`*, panel:panels(id,title,start_time,end_time)`)
       .single()

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -69,7 +69,13 @@ export interface Database {
     };
     Views: Record<string, never>;
     Functions: Record<string, never>;
-    Enums: Record<string, never>;
+    Enums: {
+      UserRole: 'ADMIN' | 'ORGANIZER' | 'ATTENDEE'
+      QuestionStatus: 'PENDING' | 'APPROVED' | 'REJECTED'
+      VoteType: 'UP' | 'DOWN'
+    };
     CompositeTypes: Record<string, never>;
   };
 }
+
+export type QuestionStatus = Database['public']['Enums']['QuestionStatus']


### PR DESCRIPTION
## Summary
- refactor event poll endpoints to use Supabase instead of Prisma
- migrate feedback APIs from Prisma to Supabase and remove extra imports
- clean question APIs and derive `QuestionStatus` from Supabase types

## Testing
- `npm test` *(fails: Invalid package.json: Expected ',' or '}' after property value)*
- `npm run lint` *(fails: Invalid package.json: Expected ',' or '}' after property value)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec332984832d8115f5d7a16409cc