### PR TITLE
feat: use nested select for panels

### DIFF
--- a/src/app/api/events/[id]/panels/route.ts
+++ b/src/app/api/events/[id]/panels/route.ts
@@ -15,17 +15,19 @@ export async function GET(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { data: panels, error } = await supabase
-      .from('panels')
-      .select('*')
-      .eq('eventId', id)
-      .order('order', { ascending: true })
+    const { data: eventWithPanels, error } = await supabase
+      .from('events')
+      .select('panels(*)')
+      .eq('id', id)
+      .order('order', { ascending: true, foreignTable: 'panels' })
+      .single()
 
     if (error) {
       console.error('Failed to fetch panels:', error)
       return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 })
     }
 
+    const panels = eventWithPanels?.panels || []
     return NextResponse.json({ panels })
   } catch (error) {
     console.error('Failed to fetch panels:', error)

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -9,6 +9,7 @@ export type Json =
 export interface Database {
   public: {
     Tables: {
+      // Events organized by users; each event can include many panels
       events: {
         Row: {
           id: string;
@@ -64,7 +65,67 @@ export interface Database {
           updatedAt?: string;
           organizerId?: string;
         };
-        Relationships: [];
+        Relationships: [
+          {
+            foreignKeyName: "events_organizerId_fkey",
+            columns: ["organizerId"],
+            referencedRelation: "users",
+            referencedColumns: ["id"],
+          },
+        ];
+      };
+      // Panels belong to events
+      panels: {
+        Row: {
+          id: string;
+          title: string;
+          description: string | null;
+          startTime: string;
+          endTime: string | null;
+          speaker: string | null;
+          location: string | null;
+          order: number;
+          isActive: boolean;
+          createdAt: string;
+          updatedAt: string;
+          eventId: string;
+        };
+        Insert: {
+          id?: string;
+          title: string;
+          description?: string | null;
+          startTime: string;
+          endTime?: string | null;
+          speaker?: string | null;
+          location?: string | null;
+          order?: number;
+          isActive?: boolean;
+          createdAt?: string;
+          updatedAt?: string;
+          eventId: string;
+        };
+        Update: {
+          id?: string;
+          title?: string;
+          description?: string | null;
+          startTime?: string;
+          endTime?: string | null;
+          speaker?: string | null;
+          location?: string | null;
+          order?: number;
+          isActive?: boolean;
+          createdAt?: string;
+          updatedAt?: string;
+          eventId?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "panels_eventId_fkey",
+            columns: ["eventId"],
+            referencedRelation: "events",
+            referencedColumns: ["id"],
+          },
+        ];
       };
     };
     Views: Record<string, never>;


### PR DESCRIPTION
## Summary
- retrieve event panels using nested select
- document event–panel relationships in types and migrations
- add RLS policies for event registrations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next not found)*
- `npx next lint` *(fails: 403 Forbidden - GET https://registry.npmjs.org/next)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f5623d30832d9f821318a434f5ec