### PR TITLE
refactor: use Supabase types for events

### DIFF
--- a/src/app/e/[slug]/page.tsx
+++ b/src/app/e/[slug]/page.tsx
@@ -11,23 +11,11 @@ import { RegistrationForm } from '@/components/shared/registration-form'
 import { EventProgramDisplay } from '@/components/shared/event-program-display'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
+import type { Database } from '@/types/supabase'
 
-interface Event {
-  id: string
-  title: string
-  description?: string
-  startDate: string
-  endDate?: string
-  location?: string
-  isPublic: boolean
-  isActive: boolean
-  program?: string
-  branding?: {
-    qrCode?: string
-  }
-  _count?: {
-    registrations: number
-  }
+type Event = Database['public']['Tables']['events']['Row'] & {
+  branding?: { qrCode?: string } | null
+  _count?: { registrations: number }
 }
 
 export default function EventPage() {

--- a/src/components/shared/registration-form.tsx
+++ b/src/components/shared/registration-form.tsx
@@ -10,19 +10,10 @@ import { Badge } from '@/components/ui/badge'
 import { User, Mail, CheckCircle, Calendar, MapPin } from 'lucide-react'
 import { format } from 'date-fns'
 import { fr } from 'date-fns/locale'
-
-interface Event {
-  id: string
-  title: string
-  description?: string
-  startDate: string
-  endDate?: string
-  location?: string
-  isActive: boolean
-}
+import type { Database } from '@/types/supabase'
 
 interface RegistrationFormProps {
-  event: Event
+  event: Database['public']['Tables']['events']['Row']
   onSubmit: (data: { email: string; consent: boolean }) => Promise<void>
   loading?: boolean
   isRegistered?: boolean


### PR DESCRIPTION
## Summary
- use Supabase generated `Database` types instead of custom `Event` interfaces
- allow event page to include registration counts while still relying on Supabase row type

## Testing
- `npx supabase gen types typescript --project-id your-project-id --schema public` *(fails: 403 Forbidden - GET https://registry.npmjs.org/supabase)*
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: sh: 1: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f566040c832d9b6ce908e7fc9258