### PR TITLE
Add Supabase auth and full RLS policies

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,9 +2,7 @@ import NextAuth, { type NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 
 import { supabase } from '@/lib/supabase'
-
 import bcrypt from 'bcryptjs'
-import { supabase } from '@/lib/supabase'
 interface Logger {
   info(message: string, meta?: Record<string, unknown>): void
   error(message: string, meta?: Record<string, unknown>): void
@@ -75,14 +73,6 @@ const authOptions: NextAuthOptions = {
           logger.warn(`Rate limited for email: ${credentials.email}`)
           return null
         }
-
-        const { data: user } = await supabase
-          .from('users')
-          .select('id, email, name, role, passwordHash')
-          .eq('email', credentials.email)
-          .maybeSingle()
-
-        if (!user || !user.passwordHash) {
 
         const { data: user, error } = await supabase
           .from('users')

--- a/supabase/migrations/202402270000_rls_policies.sql
+++ b/supabase/migrations/202402270000_rls_policies.sql
@@ -7,6 +7,7 @@ ALTER TABLE questions ENABLE ROW LEVEL SECURITY;
 ALTER TABLE polls ENABLE ROW LEVEL SECURITY;
 ALTER TABLE poll_options ENABLE ROW LEVEL SECURITY;
 ALTER TABLE poll_responses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE question_votes ENABLE ROW LEVEL SECURITY;
 ALTER TABLE certificate_templates ENABLE ROW LEVEL SECURITY;
 ALTER TABLE certificates ENABLE ROW LEVEL SECURITY;
 ALTER TABLE feedbacks ENABLE ROW LEVEL SECURITY;
@@ -44,3 +45,137 @@ CREATE POLICY "Users manage own registrations" ON event_registrations
 -- Poll responses
 CREATE POLICY "Users manage own poll responses" ON poll_responses
   FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Question votes
+CREATE POLICY "Users manage own question votes" ON question_votes
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Panels
+CREATE POLICY "Panels are viewable by everyone" ON panels
+  FOR SELECT USING (true);
+CREATE POLICY "Organizers manage panels" ON panels
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = panels.event_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = panels.event_id
+    )
+  );
+
+-- Questions
+CREATE POLICY "Questions are viewable by everyone" ON questions
+  FOR SELECT USING (true);
+CREATE POLICY "Anyone can create questions" ON questions
+  FOR INSERT WITH CHECK (true);
+CREATE POLICY "Organizers update questions" ON questions
+  FOR UPDATE USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events e
+      JOIN panels p ON p.event_id = e.id
+      WHERE p.id = panel_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events e
+      JOIN panels p ON p.event_id = e.id
+      WHERE p.id = panel_id
+    )
+  );
+CREATE POLICY "Organizers delete questions" ON questions
+  FOR DELETE USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events e
+      JOIN panels p ON p.event_id = e.id
+      WHERE p.id = panel_id
+    )
+  );
+
+-- Polls
+CREATE POLICY "Polls are viewable by everyone" ON polls
+  FOR SELECT USING (true);
+CREATE POLICY "Organizers manage polls" ON polls
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = polls.event_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = polls.event_id
+    )
+  );
+
+-- Poll options
+CREATE POLICY "Poll options are viewable by everyone" ON poll_options
+  FOR SELECT USING (true);
+CREATE POLICY "Organizers manage poll options" ON poll_options
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events e
+      JOIN polls pl ON pl.event_id = e.id
+      WHERE pl.id = poll_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events e
+      JOIN polls pl ON pl.event_id = e.id
+      WHERE pl.id = poll_id
+    )
+  );
+
+-- Certificate templates
+CREATE POLICY "Organizers manage certificate templates" ON certificate_templates
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  );
+
+-- Certificates
+CREATE POLICY "Users view own certificates" ON certificates
+  FOR SELECT USING (
+    auth.uid() = user_id OR auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  );
+CREATE POLICY "Organizers manage certificates" ON certificates
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  );
+
+-- Feedbacks
+CREATE POLICY "Users view own feedbacks" ON feedbacks
+  FOR SELECT USING (
+    auth.uid() = user_id OR auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  );
+CREATE POLICY "Users manage own feedbacks" ON feedbacks
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Helpful votes
+CREATE POLICY "Users manage own helpful votes" ON helpful_votes
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Registration tokens
+CREATE POLICY "Organizers manage registration tokens" ON registration_tokens
+  FOR ALL USING (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  ) WITH CHECK (
+    auth.uid() = (
+      SELECT organizer_id FROM events WHERE events.id = event_id
+    )
+  );

--- a/supabase/policies.sql
+++ b/supabase/policies.sql
@@ -33,3 +33,71 @@
 --   - Users can insert/update/delete only their own responses.
 --       CREATE POLICY "Users manage own poll responses" ON poll_responses
 --         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Table: question_votes
+--   - Users can manage their own votes.
+--       CREATE POLICY "Users manage own question votes" ON question_votes
+--         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Table: panels
+--   - All users can view panels; only the organizer of the related event can modify.
+--       CREATE POLICY "Panels are viewable by everyone" ON panels
+--         FOR SELECT USING (true);
+--       CREATE POLICY "Organizers manage panels" ON panels
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = panels.event_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = panels.event_id));
+
+-- Table: questions
+--   - Everyone can view and create questions.
+--   - Only event organizers can update or delete questions.
+--       CREATE POLICY "Questions are viewable by everyone" ON questions
+--         FOR SELECT USING (true);
+--       CREATE POLICY "Anyone can create questions" ON questions
+--         FOR INSERT WITH CHECK (true);
+--       CREATE POLICY "Organizers update questions" ON questions
+--         FOR UPDATE USING (auth.uid() = (SELECT organizer_id FROM events e JOIN panels p ON p.event_id = e.id WHERE p.id = panel_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events e JOIN panels p ON p.event_id = e.id WHERE p.id = panel_id));
+--       CREATE POLICY "Organizers delete questions" ON questions
+--         FOR DELETE USING (auth.uid() = (SELECT organizer_id FROM events e JOIN panels p ON p.event_id = e.id WHERE p.id = panel_id));
+
+-- Table: polls
+--   - All users can view polls; only the organizer can modify them.
+--       CREATE POLICY "Polls are viewable by everyone" ON polls
+--         FOR SELECT USING (true);
+--       CREATE POLICY "Organizers manage polls" ON polls
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = polls.event_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = polls.event_id));
+
+-- Table: poll_options
+--   - All users can view options; only the organizer can modify.
+--       CREATE POLICY "Poll options are viewable by everyone" ON poll_options
+--         FOR SELECT USING (true);
+--       CREATE POLICY "Organizers manage poll options" ON poll_options
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events e JOIN polls pl ON pl.event_id = e.id WHERE pl.id = poll_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events e JOIN polls pl ON pl.event_id = e.id WHERE pl.id = poll_id));
+
+-- Table: certificate_templates
+--   - Only event organizers can view and manage templates.
+--       CREATE POLICY "Organizers manage certificate templates" ON certificate_templates
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id));
+
+-- Table: certificates
+--   - Users can view their own certificates and organizers can manage certificates for their events.
+--       CREATE POLICY "Users view own certificates" ON certificates
+--         FOR SELECT USING (auth.uid() = user_id OR auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id));
+--       CREATE POLICY "Organizers manage certificates" ON certificates
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id));
+
+-- Table: feedbacks
+--   - Users can view their feedback and organizers can view feedback for their events.
+--   - Users can insert/update/delete only their own feedback.
+--       CREATE POLICY "Users view own feedbacks" ON feedbacks
+--         FOR SELECT USING (auth.uid() = user_id OR auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id));
+--       CREATE POLICY "Users manage own feedbacks" ON feedbacks
+--         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Table: helpful_votes
+--   - Users can manage their own helpful votes.
+--       CREATE POLICY "Users manage own helpful votes" ON helpful_votes
+--         FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+-- Table: registration_tokens
+--   - Only organizers can manage tokens for their events.
+--       CREATE POLICY "Organizers manage registration tokens" ON registration_tokens
+--         FOR ALL USING (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id)) WITH CHECK (auth.uid() = (SELECT organizer_id FROM events WHERE events.id = event_id));


### PR DESCRIPTION
## Summary
- fix NextAuth credentials flow using Supabase users table
- add row-level security policies across all tables and document them

## Testing
- `npm run lint` *(fails: next: not found)*
- `npm run db:migrate` *(fails: supabase: not found)*
- `node scripts/check-users.js` *(fails: Cannot find module '@supabase/supabase-js')*
- `./check-env.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4f56948cc832d9210d58eb2cad3ca