### PR TITLE
Add Q&A toggle for program sessions

### DIFF
--- a/scripts/seed-supabase.ts
+++ b/scripts/seed-supabase.ts
@@ -74,6 +74,7 @@ async function main() {
           location: 'Amphithéâtre Principal',
           order: 1,
           isActive: true,
+          allowQuestions: true,
           eventId: event.id
         },
         {
@@ -85,6 +86,7 @@ async function main() {
           location: 'Salle B',
           order: 2,
           isActive: true,
+          allowQuestions: false,
           eventId: event.id
         }
       ])

--- a/src/app/api/events/[id]/panels/[panelId]/route.ts
+++ b/src/app/api/events/[id]/panels/[panelId]/route.ts
@@ -16,7 +16,7 @@ export async function PATCH(
     }
 
     const body = await request.json()
-    const { title, description, startTime, endTime, speaker, location, order, isActive } = body
+    const { title, description, startTime, endTime, speaker, location, order, isActive, allowQuestions } = body
 
     const { data: event } = await supabase
       .from('events')
@@ -41,6 +41,7 @@ export async function PATCH(
     if (location !== undefined) updateData.location = location
     if (order !== undefined) updateData.order = order
     if (isActive !== undefined) updateData.isActive = isActive
+    if (allowQuestions !== undefined) updateData.allowQuestions = allowQuestions
 
     const { data: panel, error } = await supabase
       .from('panels')

--- a/src/app/api/events/[id]/panels/route.ts
+++ b/src/app/api/events/[id]/panels/route.ts
@@ -48,7 +48,7 @@ export async function POST(
     }
 
     const body = await request.json()
-    const { title, description, startTime, endTime, speaker, location, order, isActive } = body
+    const { title, description, startTime, endTime, speaker, location, order, isActive, allowQuestions } = body
 
     if (!title || !startTime) {
       return NextResponse.json({ error: 'Title and start time are required' }, { status: 400 })
@@ -79,6 +79,7 @@ export async function POST(
         location,
         order: order || 0,
         isActive: isActive ?? false,
+        allowQuestions: allowQuestions ?? false,
         eventId: id
       })
       .select()

--- a/src/app/api/events/[id]/questions/route.ts
+++ b/src/app/api/events/[id]/questions/route.ts
@@ -91,7 +91,7 @@ export async function POST(
 
     const { data: panel, error: panelError } = await supabase
       .from('panels')
-      .select('id')
+      .select('id, allowQuestions')
       .eq('id', panelId)
       .eq('event_id', id)
       .single()
@@ -100,6 +100,13 @@ export async function POST(
       return NextResponse.json(
         { error: 'Panel not found or does not belong to this event' },
         { status: 404 }
+      )
+    }
+
+    if (!panel.allowQuestions) {
+      return NextResponse.json(
+        { error: 'Questions are not allowed for this activity' },
+        { status: 403 }
       )
     }
 

--- a/src/app/dashboard/events/[id]/polls/page.tsx
+++ b/src/app/dashboard/events/[id]/polls/page.tsx
@@ -49,6 +49,7 @@ interface Panel {
   startTime: string
   endTime: string
   eventId: string
+  allowQuestions?: boolean
 }
 
 export default function EventPollsPage({ params }: { params: Promise<{ id: string }> }) {

--- a/src/app/dashboard/events/[id]/qa/page.tsx
+++ b/src/app/dashboard/events/[id]/qa/page.tsx
@@ -45,6 +45,7 @@ interface Panel {
   startTime: string
   endTime: string
   eventId: string
+  allowQuestions: boolean
 }
 
 export default function EventQAPage({ params }: { params: Promise<{ id: string }> }) {
@@ -67,9 +68,10 @@ export default function EventQAPage({ params }: { params: Promise<{ id: string }
         const panelsResponse = await fetch(`/api/events/${eventId}/panels`)
         if (panelsResponse.ok) {
           const panelsData = await panelsResponse.json()
-          setPanels(panelsData.panels || [])
-          if (panelsData.panels?.length > 0) {
-            setActivePanel(panelsData.panels[0].id)
+          const questionPanels = (panelsData.panels || []).filter((p: Panel) => p.allowQuestions)
+          setPanels(questionPanels)
+          if (questionPanels.length > 0) {
+            setActivePanel(questionPanels[0].id)
           }
         }
 

--- a/src/app/dashboard/events/[id]/recordings/page.tsx
+++ b/src/app/dashboard/events/[id]/recordings/page.tsx
@@ -52,6 +52,7 @@ interface Panel {
   startTime: string
   endTime: string
   eventId: string
+  allowQuestions?: boolean
 }
 
 interface TranscriptionJob {

--- a/src/app/events/[id]/polls/page.tsx
+++ b/src/app/events/[id]/polls/page.tsx
@@ -43,6 +43,7 @@ interface Panel {
   startTime: string
   endTime: string
   eventId: string
+  allowQuestions?: boolean
   isActive: boolean
 }
 

--- a/src/components/admin/event-program-manager.tsx
+++ b/src/components/admin/event-program-manager.tsx
@@ -36,6 +36,7 @@ interface Panel {
   location?: string
   order: number
   isActive: boolean
+  allowQuestions: boolean
   createdAt: string
   updatedAt: string
 }
@@ -68,7 +69,8 @@ export default function EventProgramManager({ eventId }: EventProgramManagerProp
     speaker: '',
     location: '',
     type: 'panel',
-    isActive: false
+    isActive: false,
+    allowQuestions: false
   })
 
   useEffect(() => {
@@ -220,7 +222,8 @@ export default function EventProgramManager({ eventId }: EventProgramManagerProp
       speaker: '',
       location: '',
       type: 'panel',
-      isActive: false
+      isActive: false,
+      allowQuestions: false
     })
     setEditingPanel(null)
   }
@@ -235,7 +238,8 @@ export default function EventProgramManager({ eventId }: EventProgramManagerProp
       speaker: panel.speaker || '',
       location: panel.location || '',
       type: 'panel', // Default type, could be stored in DB
-      isActive: panel.isActive
+      isActive: panel.isActive,
+      allowQuestions: panel.allowQuestions
     })
     setIsDialogOpen(true)
   }
@@ -373,6 +377,20 @@ export default function EventProgramManager({ eventId }: EventProgramManagerProp
 
               <div className="flex items-center justify-between">
                 <div className="space-y-0.5">
+                  <Label htmlFor="allowQuestions">Autoriser les questions</Label>
+                  <p className="text-xs text-muted-foreground">
+                    Permettre aux participants de poser des questions pour cette activité
+                  </p>
+                </div>
+                <Switch
+                  id="allowQuestions"
+                  checked={formData.allowQuestions}
+                  onCheckedChange={(checked) => handleInputChange('allowQuestions', checked)}
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
                   <Label htmlFor="isActive">Session active</Label>
                   <p className="text-xs text-muted-foreground">
                     Les sessions actives sont visibles par les participants
@@ -437,6 +455,9 @@ export default function EventProgramManager({ eventId }: EventProgramManagerProp
                           <Badge variant={panel.isActive ? 'default' : 'secondary'}>
                             {panel.isActive ? 'Actif' : 'Inactif'}
                           </Badge>
+                          {panel.allowQuestions && (
+                            <Badge variant="outline">Q&A</Badge>
+                          )}
                         </div>
                         {panel.description && (
                           <p className="text-sm text-muted-foreground mb-2">

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -86,6 +86,7 @@ export interface Database {
           location: string | null;
           order: number;
           isActive: boolean;
+          allowQuestions: boolean;
           createdAt: string;
           updatedAt: string;
           eventId: string;
@@ -100,6 +101,7 @@ export interface Database {
           location?: string | null;
           order?: number;
           isActive?: boolean;
+          allowQuestions?: boolean;
           createdAt?: string;
           updatedAt?: string;
           eventId: string;
@@ -114,6 +116,7 @@ export interface Database {
           location?: string | null;
           order?: number;
           isActive?: boolean;
+          allowQuestions?: boolean;
           createdAt?: string;
           updatedAt?: string;
           eventId?: string;

--- a/supabase/migrations/20251201000000_add_allow_questions_to_panels.sql
+++ b/supabase/migrations/20251201000000_add_allow_questions_to_panels.sql
@@ -1,0 +1,1 @@
+ALTER TABLE panels ADD COLUMN "allowQuestions" boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary
- allow organizers to enable questions per session
- block question submissions for sessions that disallow questions
- expose allowQuestions in panel APIs and types

## Testing
- `npm run lint` (fails: next: not found)
- `npm run build` (fails: next: not found)

------
https://chatgpt.com/codex/tasks/task_e_68a5037b7ea4832db441219d85894417